### PR TITLE
If Correct Answer labels are missing, don't show the button, instead of ...

### DIFF
--- a/templates/mcq.hbs
+++ b/templates/mcq.hbs
@@ -39,16 +39,20 @@
                 {{{buttons.reset}}} 
             </span>
         </a> 
+        {{#if buttons.showCorrectAnswer}}
         <a href="#" class="button model">
             <span> 
                 {{{buttons.showCorrectAnswer}}} 
             </span>
         </a>
+        {{/if}}
 
+        {{#if buttons.hideCorrectAnswer}}
         <a href="#" class="button user">
             <span>
                 {{{buttons.hideCorrectAnswer}}} 
             </span>
         </a>
+        {{/if}}
     </div>
 </div>


### PR DESCRIPTION
...an empty one.

...Also handy in an assessment where you don't want the answer shown.
