### PR TITLE
Hide input checkbox

### DIFF
--- a/less/mcq.less
+++ b/less/mcq.less
@@ -76,6 +76,7 @@
         position:absolute;
         top:14px;
         left:14px;
+        opacity: 0;
         .dir-rtl & {
             left:inherit;
             right:14px;

--- a/less/mcq.less
+++ b/less/mcq.less
@@ -77,6 +77,7 @@
         top:14px;
         left:14px;
         opacity: 0;
+        -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)"; /* IE 8 */
         .dir-rtl & {
             left:inherit;
             right:14px;


### PR DESCRIPTION
Input checkbox typically goes unseen due to opaque background-colors. However, it can be seen if screens/transparencies are used. Recommend we hide it using "opacity: 0", rather than "display: none" to avoid interfering with accessibility and other validation techniques.  

![image](https://cloud.githubusercontent.com/assets/9489014/9570666/ef901bf0-4f56-11e5-9418-f1a8805d9bc2.png)
