### PR TITLE
Hook into _canShowMarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ guide the learner’s interaction with the component.
 
 **_canShowModelAnswer** (boolean): Setting this to `false` prevents the [**_showCorrectAnswer** button](https://github.com/adaptlearning/adapt_framework/wiki/Core-Buttons) from being displayed. The default is `true`.
 
+**_canShowMarking** (boolean): Setting this to `false` prevents ticks and crosses being displayed on question completion. The default is `true`.
+
 **_recordInteraction** (boolean) Determines whether or not the learner's answers will be recorded to the LMS via cmi.interactions. Default is `true`. For further information, see the entry for `_shouldRecordInteractions` in the README for [adapt-contrib-spoor](https://github.com/adaptlearning/adapt-contrib-spoor).
 
 **_items** (array): Each *item* represents one choice for the multiple choice question and contains values for **text**, **_shouldBeSelected**, and **feedback**.

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-mcq",
   "version": "2.0.4",
-  "framework": "^2.0.0",
+  "framework": "^2.0.11",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-mcq",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new?title=contrib-mcq%3A%20please%20enter%20a%20brief%20summary%20of%20the%20issue%20here&body=please%20provide%20a%20full%20description%20of%20the%20problem,%20including%20steps%20on%20how%20to%20replicate,%20what%20browser(s)/device(s)%20the%20problem%20occurs%20on%20and,%20where%20helpful,%20screenshots.",
   "displayName" : "Multiple Choice Question",

--- a/example.json
+++ b/example.json
@@ -11,6 +11,7 @@
   "_isRandom":false,
   "_selectable":1,
   "_canShowModelAnswer": true,
+  "_canShowMarking": true,
   "_recordInteraction":true,
   "title": "MCQ",
   "displayTitle": "MCQ",

--- a/js/adapt-contrib-mcq.js
+++ b/js/adapt-contrib-mcq.js
@@ -252,6 +252,8 @@ define(function(require) {
         // This is important and should give the user feedback on how they answered the question
         // Normally done through ticks and crosses by adding classes
         showMarking: function() {
+            if (!this.model.get('_canShowMarking')) return;
+
             _.each(this.model.get('_items'), function(item, i) {
                 var $item = this.$('.component-item').eq(i);
                 $item.removeClass('correct incorrect').addClass(item._isCorrect ? 'correct' : 'incorrect');

--- a/less/mcq.less
+++ b/less/mcq.less
@@ -132,7 +132,8 @@
         .mcq-item-icon {
             display:none;
         }
-        .selected .mcq-correct-icon {
+        .incorrect .selected .mcq-correct-icon,
+        .correct .selected .mcq-correct-icon {
             display:block;
         }
     }

--- a/properties.schema
+++ b/properties.schema
@@ -97,6 +97,14 @@
       "validators": [],
       "help": "Select 'true' to allow the user to view feedback on their answer"
     },
+    "_canShowMarking": {
+      "type": "boolean",
+      "default": true,
+      "title": "Display Marking",
+      "inputType": { "type": "Boolean", "options": [ true, false ] },
+      "validators": [],
+      "help": "Select 'true' to display ticks and crosses on question completion"
+    },
     "_shouldDisplayAttempts": {
       "type":"boolean",
       "required":false,

--- a/templates/mcq.hbs
+++ b/templates/mcq.hbs
@@ -2,7 +2,7 @@
     {{> component this}}
     <div class="mcq-widget component-widget {{#unless _isEnabled}} disabled {{#if _isInteractionComplete}} complete submitted show-user-answer {{#if _isCorrect}}correct{{/if}} {{/if}} {{/unless}}">
         {{#each _items}}
-        <div class="mcq-item component-item component-item-color {{#unless ../_isEnabled}} {{#if _isCorrect}} correct{{else}} incorrect{{/if}} {{/unless}} item-{{@index}}">
+        <div class="mcq-item component-item component-item-color {{#unless ../_isEnabled}}{{#if ../_canShowMarking}}{{#if _isCorrect}}correct{{else}}incorrect{{/if}}{{/if}}{{/unless}} item-{{@index}}">
             <input type="checkbox" id="{{../_id}}-{{@index}}" aria-labelledby="{{../_id}}-{{@index}}-aria"{{#unless ../_isEnabled}} disabled{{/unless}} aria-label="{{a11y_normalize text}}"/>
             <label aria-hidden="true" id="{{../_id}}-{{@index}}-aria" for="{{../_id}}-{{@index}}" class="component-item-text-color component-item-border{{#unless ../_isEnabled}} disabled {{/unless}}{{#if _isSelected}} selected{{/if}}">
                 <div class="mcq-item-state">


### PR DESCRIPTION
Avoids adding correctness classes to items if `_canShowMarking` is false.

Please only merge once the new version of the framework has been released (v2.0.11).

Original issue: https://github.com/adaptlearning/adapt_framework/issues/1046.