### PR TITLE
Accessibility update

### DIFF
--- a/templates/mcq.hbs
+++ b/templates/mcq.hbs
@@ -4,7 +4,7 @@
         {{#each _items}}
         <div class="mcq-item component-item component-item-color {{#unless ../_isEnabled}}{{#if ../_canShowMarking}}{{#if _isCorrect}}correct{{else}}incorrect{{/if}}{{/if}}{{/unless}} item-{{@index}}">
             <input type="checkbox" id="{{../_id}}-{{@index}}" aria-labelledby="{{../_id}}-{{@index}}-aria"{{#unless ../_isEnabled}} disabled{{/unless}} aria-label="{{a11y_normalize text}}"/>
-            <label aria-hidden="true" id="{{../_id}}-{{@index}}-aria" for="{{../_id}}-{{@index}}" class="component-item-text-color component-item-border{{#unless ../_isEnabled}} disabled {{/unless}}{{#if _isSelected}} selected{{/if}}">
+            <label aria-hidden="true" id="{{../_id}}-{{@index}}-aria" for="{{../_id}}-{{@index}}" class="component-item-text-color component-item-border{{#unless ../_isEnabled}} disabled {{/unless}}{{#if _isSelected}} selected{{/if}} a11y-ignore" tabindex="-1">
                 <div class="mcq-item-state">
                     <div class="mcq-item-icon mcq-answer-icon {{#if ../_isRadio}}radio{{else}}checkbox{{/if}} component-item-text-color icon"></div>
                     <div class="mcq-item-icon mcq-correct-icon icon icon-tick"></div>


### PR DESCRIPTION
Disallow tabbing of the `<label>` and restrict to the `<input>` elements.

This is noticeable when using the function `$('').a11y_popup();` to restrict tabbable content.