### PR TITLE
#1715 - MCQ accessibility issues

### DIFF
--- a/js/mcqView.js
+++ b/js/mcqView.js
@@ -92,11 +92,9 @@ define([
                     return;
                 }
                 $itemLabel.addClass('selected');
-                $itemLabel.a11y_selected(true);
             } else {
                 selectedItems.splice(_.indexOf(selectedItems, item), 1);
                 $itemLabel.removeClass('selected');
-                $itemLabel.a11y_selected(false);
             }
             $itemInput.prop('checked', selected);
             item._isSelected = selected;
@@ -125,7 +123,6 @@ define([
         },
 
         deselectAllItems: function() {
-            this.$el.a11y_selected(false);
             this.model.deselectAllItems();
         },
 

--- a/templates/mcq.hbs
+++ b/templates/mcq.hbs
@@ -3,8 +3,8 @@
     <div class="mcq-widget component-widget {{#unless _isEnabled}} disabled {{#if _isInteractionComplete}} complete submitted show-user-answer {{#if _isCorrect}}correct{{/if}} {{/if}} {{/unless}}">
         {{#each _items}}
         <div class="mcq-item component-item component-item-color {{#unless ../_isEnabled}}{{#if ../_canShowMarking}}{{#if _isCorrect}}correct{{else}}incorrect{{/if}}{{/if}}{{/unless}} item-{{@index}}">
-            <input type="checkbox" id="{{../_id}}-{{@index}}" aria-labelledby="{{../_id}}-{{@index}}-aria"{{#unless ../_isEnabled}} disabled{{/unless}}/>
-            <label id="{{../_id}}-{{@index}}-aria" for="{{../_id}}-{{@index}}" class="component-item-text-color component-item-border{{#unless ../_isEnabled}} disabled {{/unless}}{{#if _isSelected}} selected{{/if}} a11y-ignore" tabindex="-1">
+            <input type="checkbox" id="{{../_id}}-{{@index}}"{{#unless ../_isEnabled}} disabled{{/unless}}/>
+            <label id="{{../_id}}-{{@index}}-aria" for="{{../_id}}-{{@index}}" class="component-item-text-color component-item-border{{#unless ../_isEnabled}} disabled {{/unless}}{{#if _isSelected}} selected{{/if}}">
                 <div class="mcq-item-state">
                     <div class="mcq-item-icon mcq-answer-icon {{#if ../_isRadio}}radio{{else}}checkbox{{/if}} component-item-text-color icon"></div>
                     <div class="mcq-item-icon mcq-correct-icon icon icon-tick"></div>

--- a/templates/mcq.hbs
+++ b/templates/mcq.hbs
@@ -3,8 +3,8 @@
     <div class="mcq-widget component-widget {{#unless _isEnabled}} disabled {{#if _isInteractionComplete}} complete submitted show-user-answer {{#if _isCorrect}}correct{{/if}} {{/if}} {{/unless}}">
         {{#each _items}}
         <div class="mcq-item component-item component-item-color {{#unless ../_isEnabled}}{{#if ../_canShowMarking}}{{#if _isCorrect}}correct{{else}}incorrect{{/if}}{{/if}}{{/unless}} item-{{@index}}">
-            <input type="checkbox" id="{{../_id}}-{{@index}}" aria-labelledby="{{../_id}}-{{@index}}-aria"{{#unless ../_isEnabled}} disabled{{/unless}} aria-label="{{a11y_normalize text}}"/>
-            <label aria-hidden="true" id="{{../_id}}-{{@index}}-aria" for="{{../_id}}-{{@index}}" class="component-item-text-color component-item-border{{#unless ../_isEnabled}} disabled {{/unless}}{{#if _isSelected}} selected{{/if}} a11y-ignore" tabindex="-1">
+            <input type="checkbox" id="{{../_id}}-{{@index}}" aria-labelledby="{{../_id}}-{{@index}}-aria"{{#unless ../_isEnabled}} disabled{{/unless}}/>
+            <label id="{{../_id}}-{{@index}}-aria" for="{{../_id}}-{{@index}}" class="component-item-text-color component-item-border{{#unless ../_isEnabled}} disabled {{/unless}}{{#if _isSelected}} selected{{/if}} a11y-ignore" tabindex="-1">
                 <div class="mcq-item-state">
                     <div class="mcq-item-icon mcq-answer-icon {{#if ../_isRadio}}radio{{else}}checkbox{{/if}} component-item-text-color icon"></div>
                     <div class="mcq-item-icon mcq-correct-icon icon icon-tick"></div>


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt_framework/issues/1715

The screen reader was previously reading out "internal link" when a user selects an option.

The label should not have aria-hidden="true" - Now reads "Selected [Option title]" when the user selects an option, rather than "internal link". Also do not think that an aria-label should be applied to the input checkbox when it already has an aria-labelledby attribute.