### PR TITLE
Add images to feedback

### DIFF
--- a/example.json
+++ b/example.json
@@ -21,31 +21,85 @@
   "_items": [
     {
       "text": "This is option 1.",
-      "_shouldBeSelected":true
+      "_shouldBeSelected":true,
+      "_feedbackImage": {
+        "alt": "",
+        "large": "",
+        "small": "",
+        "attribution": ""
+      }
     },
     {
       "text": "This is option 2.",
       "_shouldBeSelected":false,
+      "_feedbackImage": {
+        "alt": "",
+        "large": "",
+        "small": "",
+        "attribution": ""
+      }
       "feedback":"Option two incorrect feedback"
     },
     {
       "text": "This is option 3.",
-      "_shouldBeSelected":false
+      "_shouldBeSelected":false,
+      "_feedbackImage": {
+        "alt": "",
+        "large": "",
+        "small": "",
+        "attribution": ""
+      }
     },
     {
       "text": "This is option 4.",
-      "_shouldBeSelected":false
+      "_shouldBeSelected":false,
+      "_feedbackImage": {
+        "alt": "",
+        "large": "",
+        "small": "",
+        "attribution": ""
+      }
     }
   ],
   "_feedback":{
     "correct":"Congratulations, this is the correct feedback.",
+    "_correctImage": {
+      "alt": "",
+      "large": "",
+      "small": "",
+      "attribution": ""
+    },
     "_incorrect": {
       "notFinal": "",
-      "final": "This feedback will appear if you answered the question incorrectly."
+      "_notFinalImage": {
+        "alt": "",
+        "large": "",
+        "small": "",
+        "attribution": ""
+      },
+      "final": "This feedback will appear if you answered the question incorrectly.",
+      "_finalImage": {
+        "alt": "",
+        "large": "",
+        "small": "",
+        "attribution": ""
+      }
     },
     "_partlyCorrect": {
       "notFinal": "",
-      "final": "This feedback will appear if you answered the question correctly."
+      "_notFinalImage": {
+        "alt": "",
+        "large": "",
+        "small": "",
+        "attribution": ""
+      },
+      "final": "This feedback will appear if you answered the question correctly.",
+      "_finalImage": {
+        "alt": "",
+        "large": "",
+        "small": "",
+        "attribution": ""
+      }
     }
   },
   "_comment": "You only need to include _buttons if you want to override the button labels that are set in course.json",

--- a/js/mcqModel.js
+++ b/js/mcqModel.js
@@ -145,7 +145,8 @@ define([
         setupIndividualFeedback: function(selectedItem) {
              this.set({
                  feedbackTitle: this.get('title'),
-                 feedbackMessage: selectedItem.feedback
+                 feedbackMessage: selectedItem.feedback,
+                 feedbackImage: selectedItem._feedbackImage
              });
         },
 

--- a/properties.schema
+++ b/properties.schema
@@ -66,6 +66,48 @@
             "validators": [],
             "help": "When 'Selectable Items' is set to 1, this can be used to give the user feedback specific to the answer they selected",
             "translatable": true
+          },
+          "_feedbackImage": {
+            "type":"object",
+            "required":false,
+            "title": "Feedback image",
+            "properties":{
+              "alt": {
+                "type":"string",
+                "required":false,
+                "default": "",
+                "title": "Alternative Text",
+                "inputType": "Text",
+                "validators": [],
+                "help": "The alternative text for this image",
+                "translatable": true
+              },
+              "large": {
+                "type":"string",
+                "required":false,
+                "default": "",
+                "inputType": "Asset:image",
+                "validators": [],
+                "help": "The large sized image for desktop devices"
+              },
+              "small": {
+                "type":"string",
+                "required":false,
+                "default": "",
+                "inputType": "Asset:image",
+                "validators": [],
+                "help": "The small sized image for mobile devices"
+              },
+              "attribution": {
+                "type":"string",
+                "required":false,
+                "default": "",
+                "inputType": "Text",
+                "validators": [],
+                "help": "Text to be displayed as an attribution",
+                "translatable": true
+              }
+            }
           }
         }
       }
@@ -162,6 +204,48 @@
           "help": "Correct answer feedback for this question",
           "translatable": true
         },
+        "_correctImage": {
+          "type":"object",
+          "required":false,
+          "title": "Correct feedback image",
+          "properties":{
+            "alt": {
+              "type":"string",
+              "required":false,
+              "default": "",
+              "title": "Alternative Text",
+              "inputType": "Text",
+              "validators": [],
+              "help": "The alternative text for this image",
+              "translatable": true
+            },
+            "large": {
+              "type":"string",
+              "required":false,
+              "default": "",
+              "inputType": "Asset:image",
+              "validators": [],
+              "help": "The large sized image for desktop devices"
+            },
+            "small": {
+              "type":"string",
+              "required":false,
+              "default": "",
+              "inputType": "Asset:image",
+              "validators": [],
+              "help": "The small sized image for mobile devices"
+            },
+            "attribution": {
+              "type":"string",
+              "required":false,
+              "default": "",
+              "inputType": "Text",
+              "validators": [],
+              "help": "Text to be displayed as an attribution",
+              "translatable": true
+            }
+          }
+        },
         "_incorrect": {
           "type": "object",
           "required": false,
@@ -177,6 +261,48 @@
               "help": "Incorrect answer feedback for the final attempt",
               "translatable": true
             },
+            "_finalImage": {
+              "type":"object",
+              "required":false,
+              "title": "Incorrect final feedback image",
+              "properties":{
+                "alt": {
+                  "type":"string",
+                  "required":false,
+                  "default": "",
+                  "title": "Alternative Text",
+                  "inputType": "Text",
+                  "validators": [],
+                  "help": "The alternative text for this image",
+                  "translatable": true
+                },
+                "large": {
+                  "type":"string",
+                  "required":false,
+                  "default": "",
+                  "inputType": "Asset:image",
+                  "validators": [],
+                  "help": "The large sized image for desktop devices"
+                },
+                "small": {
+                  "type":"string",
+                  "required":false,
+                  "default": "",
+                  "inputType": "Asset:image",
+                  "validators": [],
+                  "help": "The small sized image for mobile devices"
+                },
+                "attribution": {
+                  "type":"string",
+                  "required":false,
+                  "default": "",
+                  "inputType": "Text",
+                  "validators": [],
+                  "help": "Text to be displayed as an attribution",
+                  "translatable": true
+                }
+              }
+            },
             "notFinal": {
               "type": "string",
               "required": false,
@@ -186,6 +312,48 @@
               "validators": [],
               "help": "Incorrect answer feedback for any attempt apart from the last attempt. If you leave this blank, the 'Incorrect Final' feedback will be used instead.",
               "translatable": true
+            },
+            "_notFinalImage": {
+              "type":"object",
+              "required":false,
+              "title": "Incorrect not final feedback image",
+              "properties":{
+                "alt": {
+                  "type":"string",
+                  "required":false,
+                  "default": "",
+                  "title": "Alternative Text",
+                  "inputType": "Text",
+                  "validators": [],
+                  "help": "The alternative text for this image",
+                  "translatable": true
+                },
+                "large": {
+                  "type":"string",
+                  "required":false,
+                  "default": "",
+                  "inputType": "Asset:image",
+                  "validators": [],
+                  "help": "The large sized image for desktop devices"
+                },
+                "small": {
+                  "type":"string",
+                  "required":false,
+                  "default": "",
+                  "inputType": "Asset:image",
+                  "validators": [],
+                  "help": "The small sized image for mobile devices"
+                },
+                "attribution": {
+                  "type":"string",
+                  "required":false,
+                  "default": "",
+                  "inputType": "Text",
+                  "validators": [],
+                  "help": "Text to be displayed as an attribution",
+                  "translatable": true
+                }
+              }
             }
           }
         },
@@ -203,6 +371,48 @@
               "help": "Partly correct answer feedback for the final attempt. If you leave this blank, the 'Incorrect Final' feedback will be used instead.",
               "translatable": true
             },
+            "_finalImage": {
+              "type":"object",
+              "required":false,
+              "title": "Partly correct final feedback image",
+              "properties":{
+                "alt": {
+                  "type":"string",
+                  "required":false,
+                  "default": "",
+                  "title": "Alternative Text",
+                  "inputType": "Text",
+                  "validators": [],
+                  "help": "The alternative text for this image",
+                  "translatable": true
+                },
+                "large": {
+                  "type":"string",
+                  "required":false,
+                  "default": "",
+                  "inputType": "Asset:image",
+                  "validators": [],
+                  "help": "The large sized image for desktop devices"
+                },
+                "small": {
+                  "type":"string",
+                  "required":false,
+                  "default": "",
+                  "inputType": "Asset:image",
+                  "validators": [],
+                  "help": "The small sized image for mobile devices"
+                },
+                "attribution": {
+                  "type":"string",
+                  "required":false,
+                  "default": "",
+                  "inputType": "Text",
+                  "validators": [],
+                  "help": "Text to be displayed as an attribution",
+                  "translatable": true
+                }
+              }
+            },
             "notFinal": {
               "type": "string",
               "required": false,
@@ -211,7 +421,61 @@
               "inputType": "TextArea",
               "validators": [],
               "help": "Partly correct answer feedback for any attempt apart from the last attempt. If you leave this blank, the 'Partly Correct Final' feedback will be used instead.",
-              "translatable": true
+              "translatable": true,
+              "properties": {
+                "notFinal": {
+                  "type": "string",
+                  "required": false,
+                  "default": "",
+                  "title": "Partly Correct Not Final",
+                  "inputType": "TextArea",
+                  "validators": [],
+                  "help": "Incorrect answer feedback for any attempt apart from the last attempt. If you leave this blank, the 'Incorrect Final' feedback will be used instead.",
+                  "translatable": true
+                }
+              }
+            },
+            "_notFinalImage": {
+              "type":"object",
+              "required":false,
+              "title": "Partly correct not final feedback image",
+              "properties":{
+                "alt": {
+                  "type":"string",
+                  "required":false,
+                  "default": "",
+                  "title": "Alternative Text",
+                  "inputType": "Text",
+                  "validators": [],
+                  "help": "The alternative text for this image",
+                  "translatable": true
+                },
+                "large": {
+                  "type":"string",
+                  "required":false,
+                  "default": "",
+                  "inputType": "Asset:image",
+                  "validators": [],
+                  "help": "The large sized image for desktop devices"
+                },
+                "small": {
+                  "type":"string",
+                  "required":false,
+                  "default": "",
+                  "inputType": "Asset:image",
+                  "validators": [],
+                  "help": "The small sized image for mobile devices"
+                },
+                "attribution": {
+                  "type":"string",
+                  "required":false,
+                  "default": "",
+                  "inputType": "Text",
+                  "validators": [],
+                  "help": "Text to be displayed as an attribution",
+                  "translatable": true
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
Adds support for images to be displayed in feedback. Please only merge alongside other PRs on the issue.



Original issue: https://github.com/adaptlearning/adapt_framework/issues/1734