### PR TITLE
issue/11-core Clear up isResetOnRevisit

### DIFF
--- a/js/McqModel.js
+++ b/js/McqModel.js
@@ -1,8 +1,3 @@
 import ItemsQuestionModel from 'core/js/models/itemsQuestionModel';
 
-export default class McqModel extends ItemsQuestionModel {
-  init() {
-    super.init();
-    this.set('_isCorrectAnswerShown', false);
-  }
-}
+export default class McqModel extends ItemsQuestionModel {}

--- a/js/McqView.js
+++ b/js/McqView.js
@@ -10,10 +10,6 @@ class McqView extends QuestionView {
     super.initialize(...args);
   }
 
-  resetQuestionOnRevisit() {
-    this.resetQuestion();
-  }
-
   setupQuestion() {
     this.model.setupRandomisation();
   }
@@ -64,16 +60,7 @@ class McqView extends QuestionView {
 
   // Used by the question view to reset the look and feel of the component.
   resetQuestion() {
-    this.model.resetActiveItems();
     this.model.resetItems();
-  }
-
-  showCorrectAnswer() {
-    this.model.set('_isCorrectAnswerShown', true);
-  }
-
-  hideCorrectAnswer() {
-    this.model.set('_isCorrectAnswerShown', false);
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-mcq",
   "version": "5.0.0",
-  "framework": ">=5.14.0",
+  "framework": ">=5.17.1",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-mcq",
   "bugs": "https://github.com/adaptlearning/adapt-contrib-mcq/issues",
   "component" : "mcq",


### PR DESCRIPTION
part of https://github.com/adaptlearning/adapt-contrib-core/issues/11

### Changed
* Model `reset` function to perform reset on revisit correctly

### Removed 
* View `resetQuestionOnRevisit` as performed in model
* Unnecessary call to `this.model.resetActiveItems()`
* `_isCorrectAnswerShown` behaviour moved into core in https://github.com/adaptlearning/adapt-contrib-core/pull/12