### PR TITLE
issue/3279 Fix for active item on reset

### DIFF
--- a/templates/mcq.jsx
+++ b/templates/mcq.jsx
@@ -65,7 +65,7 @@ export default function Mcq(props) {
                 `${_shouldBeSelected ? ariaLabels.correct : ariaLabels.incorrect}, ${_isActive ? ariaLabels.selectedAnswer : ariaLabels.unselectedAnswer}. ${Adapt.a11y.normalize(text)}`}
               data-adapt-index={_index}
               onKeyPress={onKeyPress}
-              onChange={onItemSelect}
+              onClick={onItemSelect}
               onFocus={onItemFocus}
               onBlur={onItemBlur}
             />

--- a/templates/mcq.jsx
+++ b/templates/mcq.jsx
@@ -59,6 +59,7 @@ export default function Mcq(props) {
               name={_isRadio ? `${_id}-item` : null}
               type={_isRadio ? 'radio' : 'checkbox'}
               disabled={!_isEnabled}
+              checked={_isActive}
               aria-label={!shouldShowMarking ?
                 Adapt.a11y.normalize(text) :
                 `${_shouldBeSelected ? ariaLabels.correct : ariaLabels.incorrect}, ${_isActive ? ariaLabels.selectedAnswer : ariaLabels.unselectedAnswer}. ${Adapt.a11y.normalize(text)}`}


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt_framework/issues/3279

### Fixed
* Active item must match model when reset