### PR TITLE
issue/2799 Removed redundant behaviour

### DIFF
--- a/js/adapt-contrib-mcq.js
+++ b/js/adapt-contrib-mcq.js
@@ -1,8 +1,8 @@
-import Adapt from 'core/js/adapt';
+import components from 'core/js/components';
 import McqView from './McqView';
 import McqModel from './McqModel';
 
-export default Adapt.register('mcq', {
+export default components.register('mcq', {
   model: McqModel,
   view: McqView
 });

--- a/templates/mcq.jsx
+++ b/templates/mcq.jsx
@@ -1,4 +1,5 @@
 import Adapt from 'core/js/adapt';
+import a11y from 'core/js/a11y';
 import React from 'react';
 import { templates, classes, compile } from 'core/js/reactHelpers';
 
@@ -57,8 +58,8 @@ export default function Mcq(props) {
               type={_isRadio ? 'radio' : 'checkbox'}
               disabled={!_isEnabled}
               aria-label={!_shouldShowMarking ?
-                Adapt.a11y.normalize(text) :
-                `${_shouldBeSelected ? ariaLabels.correct : ariaLabels.incorrect}, ${_isActive ? ariaLabels.selectedAnswer : ariaLabels.unselectedAnswer}. ${Adapt.a11y.normalize(text)}`}
+                a11y.normalize(text) :
+                `${_shouldBeSelected ? ariaLabels.correct : ariaLabels.incorrect}, ${_isActive ? ariaLabels.selectedAnswer : ariaLabels.unselectedAnswer}. ${a11y.normalize(text)}`}
               data-adapt-index={_index}
               onKeyPress={onKeyPress}
               onChange={onItemSelect}

--- a/templates/mcq.jsx
+++ b/templates/mcq.jsx
@@ -58,7 +58,7 @@ export default function Mcq(props) {
               type={_isRadio ? 'radio' : 'checkbox'}
               disabled={!_isEnabled}
               defaultChecked={_isActive}
-              aria-label={!shouldShowMarking ?
+              aria-label={!_shouldShowMarking ?
                 a11y.normalize(text) :
                 `${_shouldBeSelected ? ariaLabels.correct : ariaLabels.incorrect}, ${_isActive ? ariaLabels.selectedAnswer : ariaLabels.unselectedAnswer}. ${a11y.normalize(text)}`}
               data-adapt-index={_index}

--- a/templates/mcq.jsx
+++ b/templates/mcq.jsx
@@ -1,6 +1,6 @@
 import Adapt from 'core/js/adapt';
 import React from 'react';
-import { templates, classes, html, compile } from 'core/js/reactHelpers';
+import { templates, classes, compile } from 'core/js/reactHelpers';
 
 export default function Mcq(props) {
   const ariaLabels = Adapt.course.get('_globals')._accessibility._ariaLabels;
@@ -11,7 +11,7 @@ export default function Mcq(props) {
     _isInteractionComplete,
     _isCorrect,
     _isCorrectAnswerShown,
-    _canShowMarking,
+    _shouldShowMarking,
     _isRadio,
     displayTitle,
     body,
@@ -19,11 +19,8 @@ export default function Mcq(props) {
     onKeyPress,
     onItemSelect,
     onItemFocus,
-    onItemBlur,
-    isInteractive
+    onItemBlur
   } = props;
-
-  const shouldShowMarking = !isInteractive() && _canShowMarking;
 
   return (
     <div className='component__inner mcq__inner'>
@@ -47,8 +44,8 @@ export default function Mcq(props) {
           <div
             className={classes([
               `mcq-item item-${index}`,
-              shouldShowMarking && _shouldBeSelected && 'is-correct',
-              shouldShowMarking && !_shouldBeSelected && 'is-incorrect'
+              _shouldShowMarking && _shouldBeSelected && 'is-correct',
+              _shouldShowMarking && !_shouldBeSelected && 'is-incorrect'
             ])}
             key={_index}
           >
@@ -59,7 +56,7 @@ export default function Mcq(props) {
               name={_isRadio ? `${_id}-item` : null}
               type={_isRadio ? 'radio' : 'checkbox'}
               disabled={!_isEnabled}
-              aria-label={!shouldShowMarking ?
+              aria-label={!_shouldShowMarking ?
                 Adapt.a11y.normalize(text) :
                 `${_shouldBeSelected ? ariaLabels.correct : ariaLabels.incorrect}, ${_isActive ? ariaLabels.selectedAnswer : ariaLabels.unselectedAnswer}. ${Adapt.a11y.normalize(text)}`}
               data-adapt-index={_index}
@@ -104,8 +101,7 @@ export default function Mcq(props) {
               </div>
 
               <div className='mcq-item__text'>
-                <div className='mcq-item__text-inner'>
-                  {html(compile(text))}
+                <div className='mcq-item__text-inner' dangerouslySetInnerHTML={{ __html: compile(text) }}>
                 </div>
               </div>
 


### PR DESCRIPTION
requires https://github.com/adaptlearning/adapt-contrib-core/pull/84
part of https://github.com/adaptlearning/adapt_framework/issues/2799

### Changed
* Switched to `components.register` from `Adapt.register`
* Removed `html()` helper for `dangerouslySetInnerHtml`
* Direct import of `a11y`
* Use `_shouldShowMarking`