### PR TITLE
issue/177 - Introducing ariaQuestion field

### DIFF
--- a/example.json
+++ b/example.json
@@ -9,6 +9,7 @@
         "displayTitle": "MCQ",
         "body": "Which of the following options would you consider to be correct?",
         "instruction": "",
+        "ariaQuestion": "Question text specifically for screen readers.",
         "_attempts": 1,
         "_shouldDisplayAttempts": false,
         "_isRandom": false,

--- a/templates/mcq.jsx
+++ b/templates/mcq.jsx
@@ -17,6 +17,7 @@ export default function Mcq(props) {
     displayTitle,
     body,
     instruction,
+    ariaQuestion,
     onKeyPress,
     onItemSelect,
     onItemFocus,
@@ -37,7 +38,8 @@ export default function Mcq(props) {
           _isCorrect && 'is-correct'
         ])}
         role={_isRadio ? 'radiogroup' : 'group'}
-        aria-labelledby={(displayTitle || body || instruction) && `${_id}-header`}
+        aria-labelledby={ariaQuestion ? null : (displayTitle || body || instruction) && `${_id}-header`}
+        aria-label={ariaQuestion || null}
       >
 
         {props._items.map(({ text, _index, _isActive, _shouldBeSelected, _isHighlighted }, index) =>


### PR DESCRIPTION
fixes #177 

ariaQuestion will allow screenreaders to focus just on the question being asked instead of the screen reader reading the title, 
body & instruction fields when focusing on the group or radiogroup. We never can predict where we might script a question.