### PR TITLE
Fix: u-no-select class added to MCQ item label (fixes #192)

### DIFF
--- a/templates/mcq.jsx
+++ b/templates/mcq.jsx
@@ -73,6 +73,7 @@ export default function Mcq(props) {
             <label
               className={classes([
                 'mcq-item__label',
+                'u-no-select',
                 !_isEnabled && 'is-disabled',
                 _isHighlighted && 'is-highlighted',
                 (_isCorrectAnswerShown ? _shouldBeSelected : _isActive) && 'is-selected'


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
Fixes (#192)

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* u-no-select class added to MCQ item label #192 

[//]: # (List appropriate steps for testing if needed)
### Testing
1. Attempt to click and drag over text 
2. Ensure text can't be highlighted and instead item is selected as expected 

[//]: # (Mention any other dependencies)


