### PR TITLE
Fix: Revert touch fix for react+safari for general fix in core

### DIFF
--- a/js/McqView.js
+++ b/js/McqView.js
@@ -1,5 +1,4 @@
 import QuestionView from 'core/js/views/questionView';
-import device from 'core/js/device';
 
 class McqView extends QuestionView {
 
@@ -26,7 +25,6 @@ class McqView extends QuestionView {
   }
 
   onItemFocus(event) {
-    if (device.touch) return;
     if (!this.model.isInteractive()) return;
     if (this.model.get('_isRadio')) {
       this.onItemSelect(event);
@@ -38,7 +36,6 @@ class McqView extends QuestionView {
   }
 
   onItemBlur(event) {
-    if (device.touch) return;
     const index = $(event.currentTarget).data('adapt-index');
     const item = this.model.getChildren().findWhere({ _index: index });
     item.set('_isHighlighted', false);


### PR DESCRIPTION
fix #205 

### Fix
* Revert previous fix in favour of core fix https://github.com/adaptlearning/adapt-contrib-core/pull/351


It seems as if the issue is deeper than us wrongly using react events. I've opted for a global fix rather than need to implement this fix in every template where the issue occurs.

### Testing
Please test on ios and macos safari and on windows chrome, edge and firefox if you can
