### PR TITLE
Update: Remove ariaQuestion placeholder text (fixes #211)

### DIFF
--- a/example.json
+++ b/example.json
@@ -9,7 +9,7 @@
         "displayTitle": "MCQ",
         "body": "Which of the following options would you consider to be correct?",
         "instruction": "Choose {{#if _isRadio}}one option{{else}}one or more options{{/if}} then select Submit.",
-        "ariaQuestion": "Question text specifically for screen readers.",
+        "ariaQuestion": "",
         "_attempts": 1,
         "_shouldDisplayAttempts": false,
         "_isRandom": false,


### PR DESCRIPTION
Prevent placeholder text being copied over and left in accessible courses. Property description is noted in README and schema help/description for reference.

Fixes https://github.com/adaptlearning/adapt-contrib-mcq/issues/211

Missing `ariaQuestion` property added to [wiki](https://github.com/adaptlearning/adapt_framework/wiki/Core-model-attributes/_edit#question-model-attributes).