### PR TITLE
Fix: Title attribute added to altText in schemas (fixes #214)

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -97,6 +97,7 @@
           "altText": {
             "type": "string",
             "required": false,
+            "title": "Alternative text",
             "default": "",
             "inputType": "Text",
             "validators": [],

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -60,6 +60,7 @@
               },
               "altText": {
                 "type": "string",
+                "title": "Alternative text",
                 "description": "This will be read out by screen readers instead of reading 'text'. Optional for providing alternative text, for example, to specify how a word should be pronounced.",
                 "default": "",
                 "_adapt": {


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
#214 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Title added to altText in schemas (fixes #214)


