### PR TITLE
Fix: MCQ items assigned is-highlighted causing re-render (Issue/225)

### DIFF
--- a/js/McqView.js
+++ b/js/McqView.js
@@ -31,21 +31,11 @@ class McqView extends QuestionView {
       this.onItemSelect(event);
       return;
     }
-    const index = parseInt($(event.currentTarget).data('adapt-index'));
-    const item = this.model.getChildren().findWhere({ _index: index });
-    item.set('_isHighlighted', true);
-    setTimeout(() => {
-      Adapt.trigger('mcq:itemFocus')
-    }, 1);
+    event.currentTarget.classList.add('is-highlighted')
   }
 
   onItemBlur(event) {
-    const index = $(event.currentTarget).data('adapt-index');
-    const item = this.model.getChildren().findWhere({ _index: index });
-    item.set('_isHighlighted', false);
-    setTimeout(() => {
-      Adapt.trigger('mcq:itemFocus')
-    }, 1);
+    event.currentTarget.classList.remove('is-highlighted')
   }
 
   onItemSelect(event) {

--- a/js/McqView.js
+++ b/js/McqView.js
@@ -1,5 +1,4 @@
 import QuestionView from 'core/js/views/questionView';
-import Adapt from 'core/js/adapt';
 
 class McqView extends QuestionView {
 

--- a/js/McqView.js
+++ b/js/McqView.js
@@ -1,4 +1,5 @@
 import QuestionView from 'core/js/views/questionView';
+import Adapt from 'core/js/adapt';
 
 class McqView extends QuestionView {
 
@@ -33,12 +34,18 @@ class McqView extends QuestionView {
     const index = parseInt($(event.currentTarget).data('adapt-index'));
     const item = this.model.getChildren().findWhere({ _index: index });
     item.set('_isHighlighted', true);
+    setTimeout(() => {
+      Adapt.trigger('mcq:itemFocus')
+    }, 1);
   }
 
   onItemBlur(event) {
     const index = $(event.currentTarget).data('adapt-index');
     const item = this.model.getChildren().findWhere({ _index: index });
     item.set('_isHighlighted', false);
+    setTimeout(() => {
+      Adapt.trigger('mcq:itemFocus')
+    }, 1);
   }
 
   onItemSelect(event) {

--- a/templates/mcq.jsx
+++ b/templates/mcq.jsx
@@ -42,7 +42,7 @@ export default function Mcq(props) {
         aria-label={ariaQuestion || null}
       >
 
-        {props._items.map(({ text, altText, _index, _isActive, _shouldBeSelected, _isHighlighted }, index) =>
+        {props._items.map(({ text, altText, _index, _isActive, _shouldBeSelected }, index) =>
 
           <div
             className={classes([
@@ -75,7 +75,6 @@ export default function Mcq(props) {
                 'mcq-item__label',
                 'u-no-select',
                 !_isEnabled && 'is-disabled',
-                _isHighlighted && 'is-highlighted',
                 (_isCorrectAnswerShown ? _shouldBeSelected : _isActive) && 'is-selected'
               ])}
               aria-hidden={true}


### PR DESCRIPTION
Addresses #225 

Manually adds and removes the class for is-highlighted instead of through react.