### PR TITLE
Fix: Use aria-disabled instead of disabled on input (fixes #227)

### DIFF
--- a/templates/mcq.jsx
+++ b/templates/mcq.jsx
@@ -63,7 +63,7 @@ export default function Mcq(props) {
               id={`${_id}-${index}-input`}
               name={_isRadio ? `${_id}-item` : null}
               type={_isRadio ? 'radio' : 'checkbox'}
-              disabled={!_isEnabled}
+              aria-disabled={!_isEnabled}
               checked={_isActive}
               aria-label={!_shouldShowMarking ?
                 a11y.normalize(altText || text) :


### PR DESCRIPTION
fixes #227 

### Fix
* Allow screen reader to read aria labels on items when items are disabled
