### PR TITLE
Fix: Component does not properly display correctness icons (#254)

### DIFF
--- a/templates/mcq.jsx
+++ b/templates/mcq.jsx
@@ -12,7 +12,7 @@ export default function Mcq(props) {
     _isInteractionComplete,
     _isCorrect,
     _isCorrectAnswerShown,
-    _shouldShowMarking,
+    _canShowMarking,
     _canShowModelAnswer,
     _canShowCorrectness,
     _isRadio,
@@ -52,8 +52,8 @@ export default function Mcq(props) {
           <div
             className={classes([
               `mcq-item item-${index}`,
-              _canShowCorrectness && _shouldShowMarking && _shouldBeSelected && 'is-correct',
-              _canShowCorrectness && _shouldShowMarking && !_shouldBeSelected && 'is-incorrect'
+              _canShowMarking && _shouldBeSelected && 'is-correct',
+              _canShowMarking && !_shouldBeSelected && 'is-incorrect'
             ])}
             key={_index}
           >
@@ -65,7 +65,7 @@ export default function Mcq(props) {
               type={_isRadio ? 'radio' : 'checkbox'}
               aria-disabled={!_isEnabled}
               checked={_isActive}
-              aria-label={!_shouldShowMarking ?
+              aria-label={!_canShowMarking ?
                 a11y.normalize(altText || text) :
                 `${_shouldBeSelected ? ariaLabels.correct : ariaLabels.incorrect}, ${_isActive ? ariaLabels.selectedAnswer : ariaLabels.unselectedAnswer}. ${a11y.normalize(altText || text)}`}
               data-adapt-index={_index}

--- a/templates/mcq.jsx
+++ b/templates/mcq.jsx
@@ -12,7 +12,7 @@ export default function Mcq(props) {
     _isInteractionComplete,
     _isCorrect,
     _isCorrectAnswerShown,
-    _canShowMarking,
+    _shouldShowMarking,
     _canShowModelAnswer,
     _canShowCorrectness,
     _isRadio,
@@ -52,8 +52,8 @@ export default function Mcq(props) {
           <div
             className={classes([
               `mcq-item item-${index}`,
-              _canShowMarking && _shouldBeSelected && 'is-correct',
-              _canShowMarking && !_shouldBeSelected && 'is-incorrect'
+              _shouldShowMarking && _shouldBeSelected && 'is-correct',
+              _shouldShowMarking && !_shouldBeSelected && 'is-incorrect'
             ])}
             key={_index}
           >
@@ -65,7 +65,7 @@ export default function Mcq(props) {
               type={_isRadio ? 'radio' : 'checkbox'}
               aria-disabled={!_isEnabled}
               checked={_isActive}
-              aria-label={!_canShowMarking ?
+              aria-label={!_shouldShowMarking ?
                 a11y.normalize(altText || text) :
                 `${_shouldBeSelected ? ariaLabels.correct : ariaLabels.incorrect}, ${_isActive ? ariaLabels.selectedAnswer : ariaLabels.unselectedAnswer}. ${a11y.normalize(altText || text)}`}
               data-adapt-index={_index}


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
Fixes #254 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Updates variable from _showShowMarking to _canShowMarking, to show marking icons when enabled and are correctly updated when suppress marking is enabled in an assessment (fixing #240/ not reintroducing that bug)